### PR TITLE
Updating install_dependencies.sh and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ source venv/bin/activate
 (venv) python3 app.py
 ```
 
+Then, access the web interface through `http://127.0.0.1:5000` (if local), or `http://<server-ip>:5000` (remote).
+
 ## Major Interfaces and Functions
 
 The picture below shows the interfaces of an intial release of MobiDojo.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ MobiDojo can be easily installed on any commodity Linux (e.g., Ubuntu) machines 
 ```
 git clone https://github.com/5GSEC/MobiDojo.git
 ./install_dependencies.sh
-python3 app.py
+source venv/bin/activate
+(venv) python3 app.py
 ```
 
 ## Major Interfaces and Functions

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source venv/bin/activate
 (venv) python3 app.py
 ```
 
-Then, access the web interface through `http://127.0.0.1:5000`.
+Then, access the web interface through `http://127.0.0.1:5000` (local deployment) or `http://<remote-ip>:5000` (remote access).
 
 ## Major Interfaces and Functions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source venv/bin/activate
 (venv) python3 app.py
 ```
 
-Then, access the web interface through `http://127.0.0.1:5000` (if local), or `http://<server-ip>:5000` (remote).
+Then, access the web interface through `http://127.0.0.1:5000`.
 
 ## Major Interfaces and Functions
 

--- a/app.py
+++ b/app.py
@@ -31,4 +31,4 @@ def create_app():
 
 if __name__ == "__main__":
     app, socketio = create_app()
-    socketio.run(app, debug=True)
+    socketio.run(app, debug=True, host="0.0.0.0")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -8,7 +8,7 @@ sudo apt install -y wireshark
 
 # Docker & Docker Compose 
 sudo apt update
-sudo apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+sudo apt install -y apt-transport-https gnome-terminal ca-certificates curl gnupg-agent software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt update

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -37,7 +37,7 @@ sudo docker pull oaisoftwarealliance/oai-ausf:v2.0.0
 sudo docker pull oaisoftwarealliance/oai-upf-vpp:v2.0.0
 sudo docker pull oaisoftwarealliance/oai-nssf:v2.0.0
 sudo docker pull oaisoftwarealliance/oai-pcf:v2.0.0
-sudo docker pull oaisoftwarealliance/oai-lmf:v2.0.0
+sudo docker pull oaisoftwarealliance/oai-lmf:v2.1.0
 sudo docker pull oaisoftwarealliance/trf-gen-cn5g:latest
 sudo docker pull oaisoftwarealliance/oai-gnb:v2.1.0
 sudo docker pull oaisoftwarealliance/oai-nr-ue:v2.1.0

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Wireshark 
 sudo add-apt-repository -y ppa:wireshark-dev/stable

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -53,7 +53,7 @@ sudo apt update
 sudo apt install -y python3.11 python3.11-venv python3.11-dev
 sudo apt install -y python3-pip
 
-python3 -m venv venv
+python3.11 -m venv venv
 ./venv/bin/pip install Flask
 
 #Pyxterm

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,6 +51,9 @@ sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt update
 sudo apt install -y python3.11 python3.11-venv python3.11-dev
 sudo apt install -y python3-pip
+
+python3 -m venv venv
+source venv/bin/activate
 pip3 install Flask
 
 #Pyxterm

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -7,9 +7,9 @@ sudo apt install -y wireshark
 
 # Docker & Docker Compose 
 sudo apt update
-sudo apt install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+sudo apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt update
 # Install the latest available versions of docker-ce, docker-ce-cli, and containerd.io
 sudo apt install -y docker-ce docker-ce-cli containerd.io
@@ -71,7 +71,7 @@ pip3 install \
 #5G-Spector
 
 #5Greplay
-sudo apt update && sudo apt install gcc make git libxml2-dev libpcap-dev libconfuse-dev libsctp-dev
+sudo apt update && sudo apt install -y gcc make git libxml2-dev libpcap-dev libconfuse-dev libsctp-dev
 wget https://github.com/Montimage/mmt-dpi/releases/download/v1.7.9/mmt-dpi_1.7.9_8694eaa_Linux_x86_64.deb && sudo dpkg -i ./mmt-dpi*.deb && sudo ldconfig
 
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -54,12 +54,11 @@ sudo apt install -y python3.11 python3.11-venv python3.11-dev
 sudo apt install -y python3-pip
 
 python3 -m venv venv
-source venv/bin/activate
-pip3 install Flask
+./venv/bin/pip install Flask
 
 #Pyxterm
 git clone https://github.com/cs01/pyxtermjs.git
-pip3 install \
+./venv/bin/pip install \
     bidict==0.21.2 \
     click==8.0.1 \
     flask==2.0.1 \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -69,6 +69,7 @@ git clone https://github.com/cs01/pyxtermjs.git
     python-engineio==4.2.1 \
     python-socketio==5.4.0 \
     werkzeug==2.0.1 \
+    eventlet==0.40.3 \
     scapy
 
 #5G-Spector


### PR DESCRIPTION
This PR updates the `install_dependencies.sh` script to ensure it runs reliably on current Linux distributions. It also sets an available version for `oaisoftwarealliance/oai-lmf` (previously was failing).

The script also resolves a critical Python error by creating the virtual environment with the correct version (python3.11) and properly installing all packages locally to prevent system conflicts (required for Ubuntu 24 LTS). 

Added error handling in the shellscript, automatic apt commands (three additional `-y`), and updated `README.md` accordingly.